### PR TITLE
Bugfix/fix op show environment

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,11 @@ with open(config_path, "r") as f:
 ## Binaries
 ### op
 
-#### Implement 'op show'
+#### Implement 'op show' (DONE)
 
-It should show the environment of the current directory.
-Probably equivalent to something like `pwd | get-context`.
+<del>It should show the environment of the current directory</del>.
+<del>Probably equivalent to something like `pwd | get-context`.</del>
+
+This was implemented `Fri Mar 18 17:40:15 GMT 2022` under `op show-env`.
+
+It will show the environment where you `go`ed to last.

--- a/bin/README.md
+++ b/bin/README.md
@@ -53,12 +53,14 @@ functions --erase name op
 
 ### Example commands
 
+These examples take for granted that you have an alias to `op`, as suggested in the previous section.
+
 ```fish
 # Go to a shot
 $ op go sc010/sc010_0010
 
-# Show info on the environment
-$ op show
+# Show info on the current OpenPipe environment
+$ op show-env
 ```
 
 ### Why fish?

--- a/bin/op/op.fish
+++ b/bin/op/op.fish
@@ -20,7 +20,7 @@ function _help
     echo -e "\$ op go ../some/relative/path"
     echo -e "\n"
     echo -e "Show the current environment"
-    echo -e "\$ op show"
+    echo -e "\$ op show-env"
     echo -e "\n"
     exit 1
 end
@@ -55,13 +55,20 @@ function _go
     # Finally.. go
     echo "Going to" $destination_path
     cd $destination_path
+    set --global --export OPENPIPE_LAST_GO (realpath $destination_path)
 end
 
-function _show
+function _show_env
+
+    if ! test -n "$OPENPIPE_LAST_GO"
+        echo "No OpenPipe environment detected."
+        exit 1
+    end
+
     echo -e "\nCurrent OpenPipe environment:\n"
 
     # Split by newline and build a list
-    set env_vars (string split \n -- (pwd | get-context | tr "," "\n"))
+    set env_vars (string split \n -- (echo $OPENPIPE_LAST_GO | get-context | tr "," "\n"))
 
     for env_var in $env_vars
         # Not sure why, but 'string match' seems to be printing to sdout
@@ -90,9 +97,9 @@ switch $argv[1]
         end
         _go $argv[2]
     # op show
-    case show
+    case 'show-env'
         if test (count $argv) -ge 2
-            echo "'show' currently accepts no arguments"
+            echo "'show-env' currently accepts no arguments"
             exit 1
         end
         _show

--- a/openpipe/source_me.fish
+++ b/openpipe/source_me.fish
@@ -1,7 +1,9 @@
 # Source this file when you're doing dev stuff!
 
+set this_dir (realpath (dirname (status -f)))
+
 # Set the PATH
-set new_path (realpath ./bin)
+set new_path (realpath "$this_dir/../bin")
 set path_is_already_appended (echo $PATH | grep $new_path -c)
 
 if test $path_is_already_appended -eq 1
@@ -11,7 +13,7 @@ else
 end
 
 # Set the PYTHONPATH
-set new_python_path (realpath .)
+set new_python_path (realpath "$this_dir/..")
 set pythopath_is_already_appended (echo $PYTHONPATH | grep $new_python_path -c)
 
 if test $pythopath_is_already_appended -eq 1
@@ -21,7 +23,7 @@ else
 end
 
 # Set the config path
-set new_config_path (realpath (dirname (status -f))/configs)
+set new_config_path "$this_dir/configs"
 set config_already_appended (echo $OPENPIPE_CONFIG_PATH | grep $new_config_path -c)
 
 if test $config_already_appended -eq 1


### PR DESCRIPTION
- Fix implementation of `op show`.
- Move `op show` to `op show-env` instead
- Show env information on the _last_ environment, not on the current directory (they might be the same or not)