### PR TITLE
update docstrings

### DIFF
--- a/openpipe/templates.py
+++ b/openpipe/templates.py
@@ -2,6 +2,9 @@ import os
 import openpipe.show
 from openpipe.config import get_config
 
+# TODO: update functions documentation
+
+
 def get_template(name):
 
     templates = get_config("templates")


### PR DESCRIPTION
Even though the project is in the early life stage and the code is likely to change, I would start by adding some documentation to the `template.py` since it has been the first interaction with openpipe.

I also like to propose two changes:

1. Add python2 type annotation syntax `def get_template(name):  # type: (str) -> str`
2. Change the docstring style from sphinx to [google style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings). Overall sphinx is harder to read and IMO doesn't offer any advantages anymore since you can build a Sphinx doc even with Google or Numpy docs style: [link](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html).

NB. docs might look bloated right now while I am studying the framework.

sphinx
```py
"""Get a template with placeholder values for a given application.

:param name: the template name
    - work_area
    - default_workfile
    - maya_workfile
    - nuke_workfile
    - houdini_workfile
:type name: str
:raises ValueError: when no template is found
:return: The placeholder values for the given template
    - work_area = "$OPENPIPE_SHOW/{context_path}/work"
    - default_workfile = "{*work_area}/{context_name}_{task}_{stream}_v{version}"
    - maya_workfile = "{*default_workfile}.mb"
    - nuke_workfile = "{*default_workfile}.nk"
    - houdini_workfile = "{*default_workfile}.hip"
:rtype: str
"""
```
Google
```py
"""Get a template with placeholder values for a given application.

Args:
  name (str): the template name:
    - work_area
    - default_workfile
    - maya_workfile
    - nuke_workfile
    - houdini_workfile

Raises:
    ValueError: when no template is found.

Returns:
  str: The placeholder values for the given template:
    - work_area = "$OPENPIPE_SHOW/{context_path}/work"
    - default_workfile = "{*work_area}/{context_name}_{task}_{stream}_v{version}"
    - maya_workfile = "{*default_workfile}.mb"
    - nuke_workfile = "{*default_workfile}.nk"
    - houdini_workfile = "{*default_workfile}.hip"
"""
```